### PR TITLE
Update Miri serial bypass message

### DIFF
--- a/oxdock-buildtime-macros/src/lib.rs
+++ b/oxdock-buildtime-macros/src/lib.rs
@@ -629,6 +629,8 @@ mod tests {
     // [serial] is required because this test interacts with global state (filesystem/env)
     // which causes race conditions on high-core-count machines. CI runners often have
     // fewer cores, masking this issue not apparent there.
+    // Note: Under Miri the `#[serial]` attribute from `serial_test` is ignored —
+    // see https://github.com/palfrey/serial_test/issues/144#issuecomment-3667121315
     #[serial]
     fn errors_when_out_dir_is_file_before_build() {
         let temp = GuardedPath::tempdir().expect("tempdir");
@@ -675,6 +677,8 @@ mod tests {
     // [serial] is required because this test interacts with global state (filesystem/env)
     // which causes race conditions on high-core-count machines. CI runners often have
     // fewer cores, masking this issue not apparent there.
+    // Note: Under Miri the `#[serial]` attribute from `serial_test` is ignored —
+    // see https://github.com/palfrey/serial_test/issues/144#issuecomment-3667121315
     #[serial]
     fn errors_when_out_dir_not_writable_before_build() {
         let temp = GuardedPath::tempdir().expect("tempdir");
@@ -746,6 +750,8 @@ mod tests {
     // [serial] is required because this test interacts with global state (filesystem/env)
     // which causes race conditions on high-core-count machines. CI runners often have
     // fewer cores, masking this issue not apparent there.
+    // Note: Under Miri the `#[serial]` attribute from `serial_test` is ignored —
+    // see https://github.com/palfrey/serial_test/issues/144#issuecomment-3667121315
     #[serial]
     fn uses_out_dir_when_not_primary_and_no_git() {
         let temp = GuardedPath::tempdir().expect("tempdir");
@@ -793,6 +799,8 @@ mod tests {
     // [serial] is required because this test interacts with global state (filesystem/env)
     // which causes race conditions on high-core-count machines. CI runners often have
     // fewer cores, masking this issue not apparent there.
+    // Note: Under Miri the `#[serial]` attribute from `serial_test` is ignored —
+    // see https://github.com/palfrey/serial_test/issues/144#issuecomment-3667121315
     #[serial]
     fn prepare_errors_without_out_dir_when_not_primary_and_no_git() {
         let temp = GuardedPath::tempdir().expect("tempdir");
@@ -825,6 +833,8 @@ mod tests {
     // [serial] is required because this test interacts with global state (filesystem/env)
     // which causes race conditions on high-core-count machines. CI runners often have
     // fewer cores, masking this issue not apparent there.
+    // Note: Under Miri the `#[serial]` attribute from `serial_test` is ignored —
+    // see https://github.com/palfrey/serial_test/issues/144#issuecomment-3667121315
     #[serial]
     fn errors_without_out_dir_when_not_primary_and_no_git() {
         let temp = GuardedPath::tempdir().expect("tempdir");
@@ -856,6 +866,8 @@ mod tests {
     // [serial] is required because this test interacts with global state (filesystem/env)
     // which causes race conditions on high-core-count machines. CI runners often have
     // fewer cores, masking this issue not apparent there.
+    // Note: Under Miri the `#[serial]` attribute from `serial_test` is ignored —
+    // see https://github.com/palfrey/serial_test/issues/144#issuecomment-3667121315
     #[serial]
     fn builds_from_manifest_dir_when_primary_with_git() {
         let temp = GuardedPath::tempdir().expect("tempdir");
@@ -911,6 +923,8 @@ mod tests {
     // [serial] is required because this test interacts with global state (filesystem/env)
     // which causes race conditions on high-core-count machines. CI runners often have
     // fewer cores, masking this issue not apparent there.
+    // Note: Under Miri the `#[serial]` attribute from `serial_test` is ignored —
+    // see https://github.com/palfrey/serial_test/issues/144#issuecomment-3667121315
     #[serial]
     fn uses_final_workdir_for_folder() {
         let temp = GuardedPath::tempdir().expect("tempdir");


### PR DESCRIPTION
This PR is a comment addition which explains why #[serial] is bypasses for testing when using [Miri](https://github.com/rust-lang/miri).